### PR TITLE
Changing to update on_tick

### DIFF
--- a/actions/ToggleTransport/ToggleTransport.py
+++ b/actions/ToggleTransport/ToggleTransport.py
@@ -36,8 +36,6 @@ class ToggleTransport(ActionBase):
         self.set_state( 0 )
       
     def set_state( self, state ):
-        if state == self.current_state:
-            return
         self.current_state = state
         if state == 0:
             icon_name = "play.png"
@@ -46,6 +44,9 @@ class ToggleTransport(ActionBase):
             icon_name = "stop.png"
             self.set_bottom_label("Stop", font_size=16)
         self.set_icon( icon_name )
+
+    def on_tick(self) -> None:
+        self.set_state(self.current_state)
         
     def on_key_up(self) -> None:
         pass

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,1 +1,6 @@
-python-osc>=1.9.0
+loguru==0.7.2
+plumbum==1.8.3
+pyparsing==3.1.4
+python-osc==1.9.0
+rpyc==6.0.0
+streamcontroller-plugin-tools==2.0.1

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ class MixbusPlugin(PluginBase):
     def __init__(self):
         super().__init__()
         log.debug("MixbusPlugin started")
-        self.launch_backend(os.path.join(self.PATH, "backend", "backend.py"), open_in_terminal=True)
+        self.launch_backend(os.path.join(self.PATH, "backend", "backend.py"), open_in_terminal=True, venv_path=os.path.join(self.PATH, ".venv"))
         
         # Register plugin
         self.register(


### PR DESCRIPTION
There seems to be some race condition doing this only during `on_ready`, so this calls during `on_tick` and lets the image upload successfully.  Also be sure to validate that the action has the Set Media allowable (the image icon should be blue)
![image](https://github.com/user-attachments/assets/a1f59b91-6c81-47fe-8196-b463fa2ada41)

This also adds a few quality of life things:
- Make sure to set the `.venv` path for the plugin so it loads the proper dependencies
- Export all the required tools to requirements.txt