### PR TITLE
fix: bind ActionHolder args by keyword (survives arg-order change, prevents UI-init crash)

### DIFF
--- a/AccessActionHolder.py
+++ b/AccessActionHolder.py
@@ -25,13 +25,17 @@ class AccessActionHolder(ActionHolder):
             Input.Touchscreen: ActionInputSupport.UNTESTED
         },
         *args, **kwargs):
-        super().__init__ ( plugin_base, action_base, action_name,
-            icon,
-            min_app_version,
-            action_id,
-            action_id_suffix,
-            action_support,
-            *args, **kwargs 
+        # Bind by keyword: ActionHolder's positional order is not stable across StreamController releases -- a misbind lands the action class in action_name and aborts UI init.
+        super().__init__(
+            plugin_base,
+            action_name=action_name,
+            action_base=action_base,
+            icon=icon,
+            min_app_version=min_app_version,
+            action_id=action_id,
+            action_id_suffix=action_id_suffix,
+            action_support=action_support,
+            *args, **kwargs,
         )
         self.access_action_path = access_action_path
         self.icon_name = icon_name


### PR DESCRIPTION
## Problem
On StreamController 1.5.0-beta.14, opening the editor with this plugin loaded
crashes the main window:

    TypeError: Must be string, not type
    Gtk.Label(label=action_holder.action_name)   # ActionChooser.py

The sidebar build aborts, so the UI never finishes initializing (cascading
"MainWindow has no attribute 'sidebar'").

## Cause
beta.14 reordered `ActionHolder.__init__` (`action_core` was inserted;
`action_name` now precedes `action_base`). `AccessActionHolder` calls
`super().__init__` positionally in the old order, so the action class lands in
the `action_name` slot and reaches `Gtk.Label` as a type.

## Fix
Bind the forwarded args by keyword. The names are identical across the old and
new `ActionHolder` signatures, so this is order-independent and
backwards-compatible (works on current and older StreamController). Minimal and
behavior-preserving (keeps `action_base`; no migration to `action_core`).
